### PR TITLE
Fix: Improving autocomplete functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "drupal-sdc-autocomplete" extension will be documente
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [1.0.5] - 2024-10-25
 
-- Initial release
+### Fixed
+
+- Fixed the autocomplete so that it would autosuggest only the components maching the already entered theme/module name prefix.
+- Fixed the continues re-appearing of autocomplete modal when the match has already been found & accepted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,5 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 
-- Fixed the autocomplete so that it would autosuggest only the components maching the already entered theme/module name prefix.
+- Fixed the autocomplete so that it would autosuggest only the components matching the already entered theme/module name prefix.
 - Fixed the continues re-appearing of autocomplete modal when the match has already been found & accepted.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/wunderio/drupal-sdc-helper.git"
   },
-  "version": "1.0.3",
+  "version": "1.0.5",
   "publisher": "davis-are",
   "pricing": "Free",
   "keywords": [
@@ -68,7 +68,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.7",
     "@types/node": "20.x",
-    "@types/vscode": "^1.93.0",
+    "@types/vscode": "^1.91.1",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
     "@vscode/test-cli": "^0.0.10",

--- a/src/ComponentCompletionItemProvider.ts
+++ b/src/ComponentCompletionItemProvider.ts
@@ -13,9 +13,23 @@ export class ComponentCompletionItemProvider implements vscode.CompletionItemPro
       return [];
     }
 
-    const components = await getComponentIndex();
+    // Ensure there's a machine_name: prefix
+    const machineNameMatch = linePrefix.match(/[A-Za-z0-9_-]+:$/);
+    if (!machineNameMatch) {
+      return [];
+    }
 
-    return components.map(component => {
+    const components = await getComponentIndex();
+    const machineNamePrefix = machineNameMatch[0];
+
+    // Filter components to only those that match the machine name prefix exactly
+    const matchedComponents = components.filter(component => component.id.startsWith(machineNamePrefix));
+
+    if (matchedComponents.length === 0) {
+      return [];
+    }
+
+    return matchedComponents.map(component => {
       const item = new vscode.CompletionItem(
         component.id,
         vscode.CompletionItemKind.File, // Changed to File for IntelliSense-like completion
@@ -23,18 +37,8 @@ export class ComponentCompletionItemProvider implements vscode.CompletionItemPro
       item.detail = 'Drupal SDC Component';
       item.documentation = new vscode.MarkdownString(`Path: ${component.path}`);
 
-      const machineNameMatch = linePrefix.match(/[A-Za-z0-9_-]+:$/);
-      let insertText = component.id;
-
-      if (machineNameMatch) {
-        const typedPrefix = machineNameMatch[0];
-        if (component.id.startsWith(typedPrefix)) {
-          insertText = component.id.replace(typedPrefix, ''); // Avoid re-adding the prefix
-        }
-      }
-
-      // Set the insertText for the completion item
-      item.insertText = insertText;
+      // Set the insertText for the completion item, excluding the machine_name prefix if already present
+      item.insertText = component.id.replace(machineNamePrefix, '');
 
       // Optionally, re-trigger the suggestion list after a completion is inserted
       item.command = { command: 'editor.action.triggerSuggest', title: 'Re-trigger completions...' };


### PR DESCRIPTION
## [1.0.5] - 2024-10-25

### Fixed

- Fixed the autocomplete so that it would autosuggest only the components matching the already entered theme/module name prefix.
- Fixed the continues re-appearing of autocomplete modal when the match has already been found & accepted.